### PR TITLE
Añadidas complejidades de Dantzig y de Simplex

### DIFF
--- a/resumen/04-camino-minimo.md
+++ b/resumen/04-camino-minimo.md
@@ -270,6 +270,8 @@ fin para
 retornar L
 ```
 
+**Complejidad de Dantzig**: [O(mn^2 log n)](https://users-cs.au.dk/tdh/papers/Dantzig.pdf)
+
 #### SIMPLEX (CLRS)
 ```
 SIMPLEX(A,b,c):
@@ -295,6 +297,8 @@ SIMPLEX(A,b,c):
             xᵢ = 0
     return (x₁, x₂, ⋯, xₙ)
 ```
+
+[**Nota sobre la complejidad de Simplex:**](https://cstheory.stackexchange.com/questions/2373/complexity-of-the-simplex-algorithm/2374) The simplex algorithm indeed visits all 2^n vertices in the worst case (Klee & Minty 1972), and this turns out to be true for any deterministic pivot rule. However Spielman and Teng (2001) proved that when the inputs to the algorithm are slightly randomly perturbed, the expected running time of the simplex algorithm is polynomial for any inputs -- this basically says that for any problem there is a "nearby" one that the simplex method will efficiently solve, and it pretty much covers every real-world linear program you'd like to solve. Afterwards, Kelner and Spielman (2006) introduced a polynomial time randomized simplex algorithm that truley works on any inputs, even the bad ones for the original simplex algorithm.
 
 Teoremas sobre Camino Mínimo
 ============================


### PR DESCRIPTION
Hoy estuve estudiando un toque de acá para el parcial y noté que las complejidades de Dantzig y Simplex no están presentes. Si bien la complejidad de Dantzig tampoco está presente en las diapositivas - ni prácticamente en internet -, encontré un paper que habla de cuánto cuesta obtener un camino más corto usando lo que parece ser el algoritmo de Dantzig. Los agrego por completitud. En cada título a la complejidad del algoritmo puse también un link apuntando a la fuente de donde saqué esos valores, en caso de que haya que revisarlos o se quiera más información.